### PR TITLE
Use `const` references to avoid unnecessary copies

### DIFF
--- a/include/binarytree/binary_tree.h
+++ b/include/binarytree/binary_tree.h
@@ -21,21 +21,23 @@ class BinaryTree
 {
   static_assert(is_comparable_v<T>, "Type T must be comparable using < operator");
 public:
-  BinaryTree();
+   BinaryTree();
   ~BinaryTree();
 
-  void insert(T value);
-  bool search(T value);
-  void remove(T value);
+  void insert(const T &value);
+  bool search(const T &value);
+  void remove(const T &value);
 
 private:
-  TreeNode<T>* m_root;
+  TreeNode<T>* m_root = nullptr;
 
-  void insert_pvt(TreeNode<T>*& node, T value);
-  bool search_pvt(TreeNode<T>* node, T value);
-  TreeNode<T>* remove_pvt(TreeNode<T>* node, T value);
-  TreeNode<T>* findMin_pvt(TreeNode<T>* node);
-  void destroyTree_pvt(TreeNode<T>* node);
+  // ---- Helper methods ---- //
+
+  void insert_pvt(TreeNode<T>*& node, const T &value) const;
+  bool search_pvt(const TreeNode<T>* const node, const T &value) const;
+  TreeNode<T>* remove_pvt(TreeNode<T>* node, const T &value) const;
+  TreeNode<T>* findMin_pvt(TreeNode<T>* node) const;
+  void destroyTree_pvt(const TreeNode<T>* const node) const;
 };
 
 } // namespace ddlib

--- a/include/binarytree/binary_tree.tpp
+++ b/include/binarytree/binary_tree.tpp
@@ -10,7 +10,7 @@ namespace ddlib
 
 template <typename T>
 BinaryTree<T>::BinaryTree()
-: m_root(nullptr) {}
+{}
 
 template <typename T>
 BinaryTree<T>::~BinaryTree()
@@ -19,13 +19,13 @@ BinaryTree<T>::~BinaryTree()
 }
 
 template <typename T>
-void BinaryTree<T>::insert(T value)
+void BinaryTree<T>::insert(const T &value)
 {
   insert_pvt(m_root, value);
 }
 
 template <typename T>
-void BinaryTree<T>::insert_pvt(TreeNode<T>*& node, T value)
+void BinaryTree<T>::insert_pvt(TreeNode<T>* &node, const T &value) const
 {
   if (node == nullptr)
   {
@@ -42,13 +42,13 @@ void BinaryTree<T>::insert_pvt(TreeNode<T>*& node, T value)
 }
 
 template <typename T>
-bool BinaryTree<T>::search(T value)
+bool BinaryTree<T>::search(const T &value)
 {
   return search_pvt(m_root, value);
 }
 
 template <typename T>
-bool BinaryTree<T>::search_pvt(TreeNode<T>* node, T value)
+bool BinaryTree<T>::search_pvt(const TreeNode<T>* const node, const T &value) const
 {
   if (node == nullptr)
   {
@@ -69,17 +69,17 @@ bool BinaryTree<T>::search_pvt(TreeNode<T>* node, T value)
 }
 
 template <typename T>
-void BinaryTree<T>::remove(T value)
+void BinaryTree<T>::remove(const T &value)
 {
   m_root = remove_pvt(m_root, value);
 }
 
 template <typename T>
-TreeNode<T>* BinaryTree<T>::remove_pvt(TreeNode<T>* node, T value)
+TreeNode<T>* BinaryTree<T>::remove_pvt(TreeNode<T>* node, const T &value) const
 {
   if (node == nullptr)
   {
-    return nullptr;
+    return nullptr; // Base case: value not found
   }
   else if (value < node->m_value)
   {
@@ -91,45 +91,52 @@ TreeNode<T>* BinaryTree<T>::remove_pvt(TreeNode<T>* node, T value)
   }
   else
   {
+    // Node to remove found (it contains the searched value)
     if (node->m_left == nullptr && node->m_right == nullptr)
     {
+      // Node has no children: just delete it
       delete node;
       node = nullptr;
     }
     else if (node->m_left == nullptr)
     {
+      // Node has only right child: replace it with the right child and delete the node
       TreeNode<T>* temp = node;
       node = node->m_right;
       delete temp;
     }
     else if (node->m_right == nullptr)
     {
+      // Node has only left child: replace it with the left child and delete the node
       TreeNode<T>* temp = node;
       node = node->m_left;
       delete temp;
     }
     else
     {
+      // Node has two children: replace it with the minimum value in the right subtree
       TreeNode<T>* temp = findMin_pvt(node->m_right);
       node->m_value = temp->m_value;
       node->m_right = remove_pvt(node->m_right, temp->m_value);
     }
   }
+
   return node;
 }
 
 template <typename T>
-TreeNode<T>* BinaryTree<T>::findMin_pvt(TreeNode<T>* node)
+TreeNode<T>* BinaryTree<T>::findMin_pvt(TreeNode<T>* node) const
 {
   while (node->m_left != nullptr)
   {
     node = node->m_left;
   }
+
   return node;
 }
 
 template <typename T>
-void BinaryTree<T>::destroyTree_pvt(TreeNode<T>* node)
+void BinaryTree<T>::destroyTree_pvt(const TreeNode<T>* const node) const
 {
   if (node != nullptr)
   {

--- a/include/binarytree/tree_node.h
+++ b/include/binarytree/tree_node.h
@@ -11,17 +11,19 @@ namespace ddlib
 
 /**
  * @brief The `TreeNode` structure represents a node in a binary tree. It can contain a value of type `T` and pointers
- * to the left and right children (if any).
+ * to the left and right children (if any).\n
+ * The data members are public for simplicity. If they were private, we would need to provide getters and setters.
  **/
 template <typename T>
 struct TreeNode
 {
   T m_value;
-  TreeNode* m_left;
-  TreeNode* m_right;
+  TreeNode* m_left  = nullptr;
+  TreeNode* m_right = nullptr;
 
-  TreeNode(T val)
-  : m_value(val), m_left(nullptr), m_right(nullptr) {}
+  TreeNode(const T &value)
+  : m_value(value)
+  {}
 };
 
 } // namespace ddlib

--- a/tests/test_binary_tree.cpp
+++ b/tests/test_binary_tree.cpp
@@ -52,7 +52,7 @@ TEST(BinaryTreeTest, InsertAndSearchComparable)
 
 TEST(BinaryTreeTest, InsertNotComparable)
 {
-  // This will not compile: type must implement the < operator. Uncomment the following lines to see the compilation error.
+  // // This will not compile: type must implement the < operator. Uncomment the following lines to see the compilation error.
   // ddlib::BinaryTree<NotComparable> tree;
 }
 


### PR DESCRIPTION
Closes #1.

#### `include\binarytree\tree_node.h`
- Used `const` references in the `TreeNode` constructor to avoid unnecessary copies.
- Children nodes are now initialised with `nullptr` in the class declaration.
- Improved documentation.

#### `include\binarytree\binary_tree.h`
#### `include\binarytree\binary_tree.tpp`
- Used `const` references for public and private methods to avoid unnecessary copies.
- Root node is now initialised with `nullptr` in the class declaration.
- Flagged methods as `const` where appropriate.
- Improved documentation.