### PR TITLE
Use smart pointers instead of raw pointers

### DIFF
--- a/include/binarytree/binary_tree.h
+++ b/include/binarytree/binary_tree.h
@@ -8,6 +8,7 @@
 
 #include "is_comparable.h" // custom type trait to check if a type is comparable
 #include "tree_node.h"
+#include <memory>
 
 namespace ddlib
 {
@@ -25,19 +26,18 @@ public:
   ~BinaryTree();
 
   void insert(const T &value);
-  bool search(const T &value);
+  bool search(const T &value) const;
   void remove(const T &value);
 
 private:
-  TreeNode<T>* m_root = nullptr;
+  std::unique_ptr<TreeNode<T>> m_root;
 
   // ---- Helper methods ---- //
 
-  void insert_pvt(TreeNode<T>*& node, const T &value) const;
+  void insert_pvt(std::unique_ptr<TreeNode<T>>& node, const T &value) const;
   bool search_pvt(const TreeNode<T>* const node, const T &value) const;
-  TreeNode<T>* remove_pvt(TreeNode<T>* node, const T &value) const;
+  std::unique_ptr<TreeNode<T>> remove_pvt(std::unique_ptr<TreeNode<T>> node, const T &value) const;
   TreeNode<T>* findMin_pvt(TreeNode<T>* node) const;
-  void destroyTree_pvt(const TreeNode<T>* const node) const;
 };
 
 } // namespace ddlib

--- a/include/binarytree/binary_tree.h
+++ b/include/binarytree/binary_tree.h
@@ -35,9 +35,9 @@ private:
   // ---- Helper methods ---- //
 
   void insert_pvt(std::unique_ptr<TreeNode<T>>& node, const T &value) const;
-  bool search_pvt(const TreeNode<T>* const node, const T &value) const;
+  bool search_pvt(const std::unique_ptr<TreeNode<T>> &node, const T &value) const;
   std::unique_ptr<TreeNode<T>> remove_pvt(std::unique_ptr<TreeNode<T>> node, const T &value) const;
-  TreeNode<T>* findMin_pvt(TreeNode<T>* node) const;
+  const std::unique_ptr<TreeNode<T>>& findMin_pvt(const std::unique_ptr<TreeNode<T>>& node) const;
 };
 
 } // namespace ddlib

--- a/include/binarytree/binary_tree.tpp
+++ b/include/binarytree/binary_tree.tpp
@@ -14,9 +14,7 @@ BinaryTree<T>::BinaryTree()
 
 template <typename T>
 BinaryTree<T>::~BinaryTree()
-{
-  destroyTree_pvt(m_root);
-}
+{}
 
 template <typename T>
 void BinaryTree<T>::insert(const T &value)
@@ -25,11 +23,11 @@ void BinaryTree<T>::insert(const T &value)
 }
 
 template <typename T>
-void BinaryTree<T>::insert_pvt(TreeNode<T>* &node, const T &value) const
+void BinaryTree<T>::insert_pvt(std::unique_ptr<TreeNode<T>> &node, const T &value) const
 {
   if (node == nullptr)
   {
-    node = new TreeNode<T>(value);
+    node = std::make_unique<TreeNode<T>>(value);
   }
   else if (value < node->m_value)
   {
@@ -42,9 +40,9 @@ void BinaryTree<T>::insert_pvt(TreeNode<T>* &node, const T &value) const
 }
 
 template <typename T>
-bool BinaryTree<T>::search(const T &value)
+bool BinaryTree<T>::search(const T &value) const
 {
-  return search_pvt(m_root, value);
+  return search_pvt(m_root.get(), value);
 }
 
 template <typename T>
@@ -60,22 +58,22 @@ bool BinaryTree<T>::search_pvt(const TreeNode<T>* const node, const T &value) co
   }
   else if (value < node->m_value)
   {
-    return search_pvt(node->m_left, value);
+    return search_pvt(node->m_left.get(), value);
   }
   else
   {
-    return search_pvt(node->m_right, value);
+    return search_pvt(node->m_right.get(), value);
   }
 }
 
 template <typename T>
 void BinaryTree<T>::remove(const T &value)
 {
-  m_root = remove_pvt(m_root, value);
+  m_root = remove_pvt(std::move(m_root), value);
 }
 
 template <typename T>
-TreeNode<T>* BinaryTree<T>::remove_pvt(TreeNode<T>* node, const T &value) const
+std::unique_ptr<TreeNode<T>> BinaryTree<T>::remove_pvt(std::unique_ptr<TreeNode<T>> node, const T &value) const
 {
   if (node == nullptr)
   {
@@ -83,41 +81,36 @@ TreeNode<T>* BinaryTree<T>::remove_pvt(TreeNode<T>* node, const T &value) const
   }
   else if (value < node->m_value)
   {
-    node->m_left = remove_pvt(node->m_left, value);
+    node->m_left = remove_pvt(std::move(node->m_left), value);
   }
   else if (value > node->m_value)
   {
-    node->m_right = remove_pvt(node->m_right, value);
+    node->m_right = remove_pvt(std::move(node->m_right), value);
   }
   else
   {
     // Node to remove found (it contains the searched value)
     if (node->m_left == nullptr && node->m_right == nullptr)
     {
-      // Node has no children: just delete it
-      delete node;
+      // Node has no children: since `node` is a `unique_ptr`, it will be automatically deleted
       node = nullptr;
     }
     else if (node->m_left == nullptr)
     {
       // Node has only right child: replace it with the right child and delete the node
-      TreeNode<T>* temp = node;
-      node = node->m_right;
-      delete temp;
+      return std::move(node->m_right);
     }
     else if (node->m_right == nullptr)
     {
       // Node has only left child: replace it with the left child and delete the node
-      TreeNode<T>* temp = node;
-      node = node->m_left;
-      delete temp;
+      return std::move(node->m_left);
     }
     else
     {
       // Node has two children: replace it with the minimum value in the right subtree
-      TreeNode<T>* temp = findMin_pvt(node->m_right);
+      TreeNode<T>* temp = findMin_pvt(node->m_right.get());
       node->m_value = temp->m_value;
-      node->m_right = remove_pvt(node->m_right, temp->m_value);
+      node->m_right = remove_pvt(std::move(node->m_right), temp->m_value);
     }
   }
 
@@ -129,21 +122,11 @@ TreeNode<T>* BinaryTree<T>::findMin_pvt(TreeNode<T>* node) const
 {
   while (node->m_left != nullptr)
   {
-    node = node->m_left;
+    node = node->m_left.get();
   }
 
   return node;
 }
 
-template <typename T>
-void BinaryTree<T>::destroyTree_pvt(const TreeNode<T>* const node) const
-{
-  if (node != nullptr)
-  {
-    destroyTree_pvt(node->m_left);
-    destroyTree_pvt(node->m_right);
-    delete node;
-  }
-}
 
 } // namespace ddlib

--- a/include/binarytree/binary_tree.tpp
+++ b/include/binarytree/binary_tree.tpp
@@ -99,7 +99,7 @@ std::unique_ptr<TreeNode<T>> BinaryTree<T>::remove_pvt(std::unique_ptr<TreeNode<
     if (node->m_left == nullptr && node->m_right == nullptr)
     {
       // Node has no children: since `node` is a `unique_ptr`, it will be automatically deleted
-      node = nullptr; // Calls the destructor of the node
+      node.reset(nullptr); // Calls the destructor of the node
     }
     else if (node->m_left == nullptr)
     {

--- a/include/binarytree/binary_tree.tpp
+++ b/include/binarytree/binary_tree.tpp
@@ -87,7 +87,7 @@ std::unique_ptr<TreeNode<T>> BinaryTree<T>::remove_pvt(std::unique_ptr<TreeNode<
   }
   else if (value < node->m_value)
   {
-    node->m_left = remove_pvt(std::move(node->m_left), value);
+    node->m_left = remove_pvt(std::move(node->m_left), value); // remove_pvt returns an rvalue, so that node->m_left can release its owned object (if any) and take ownership of the new object
   }
   else if (value > node->m_value)
   {
@@ -103,12 +103,12 @@ std::unique_ptr<TreeNode<T>> BinaryTree<T>::remove_pvt(std::unique_ptr<TreeNode<
     }
     else if (node->m_left == nullptr)
     {
-      // Node has only right child: replace it with the right child and delete the node
+      // Node has only right child: replace node with its right child and delete the node
       return std::move(node->m_right);
     }
     else if (node->m_right == nullptr)
     {
-      // Node has only left child: replace it with the left child and delete the node
+      // Node has only left child: replace node with its left child and delete the node
       return std::move(node->m_left);
     }
     else
@@ -120,7 +120,7 @@ std::unique_ptr<TreeNode<T>> BinaryTree<T>::remove_pvt(std::unique_ptr<TreeNode<
     }
   }
 
-  return node;
+  return node; // moves (not copies) the node back to the caller
 }
 
 /**

--- a/include/binarytree/binary_tree.tpp
+++ b/include/binarytree/binary_tree.tpp
@@ -3,8 +3,6 @@
  * @brief Implementation file for the `BinaryTree` class.
  **/
 
-#include "binary_tree.h"
-
 namespace ddlib
 {
 
@@ -42,11 +40,19 @@ void BinaryTree<T>::insert_pvt(std::unique_ptr<TreeNode<T>> &node, const T &valu
 template <typename T>
 bool BinaryTree<T>::search(const T &value) const
 {
-  return search_pvt(m_root.get(), value);
+  return search_pvt(m_root, value);
 }
 
+/**
+ * @brief Search for a value in the tree.
+ * Receives a reference to a `const` unique pointer to a `TreeNode` because the node is not modified during the search.
+ *
+ * @param node The node to start the search from
+ * @param value The value to search for
+ * @return bool
+ **/
 template <typename T>
-bool BinaryTree<T>::search_pvt(const TreeNode<T>* const node, const T &value) const
+bool BinaryTree<T>::search_pvt(const std::unique_ptr<TreeNode<T>> &node, const T &value) const
 {
   if (node == nullptr)
   {
@@ -58,11 +64,11 @@ bool BinaryTree<T>::search_pvt(const TreeNode<T>* const node, const T &value) co
   }
   else if (value < node->m_value)
   {
-    return search_pvt(node->m_left.get(), value);
+    return search_pvt(node->m_left, value);
   }
   else
   {
-    return search_pvt(node->m_right.get(), value);
+    return search_pvt(node->m_right, value);
   }
 }
 
@@ -73,7 +79,7 @@ void BinaryTree<T>::remove(const T &value)
 }
 
 template <typename T>
-std::unique_ptr<TreeNode<T>> BinaryTree<T>::remove_pvt(std::unique_ptr<TreeNode<T>> node, const T &value) const
+std::unique_ptr<TreeNode<T>> BinaryTree<T>::remove_pvt(std::unique_ptr<TreeNode<T>> node, const T& value) const
 {
   if (node == nullptr)
   {
@@ -93,7 +99,7 @@ std::unique_ptr<TreeNode<T>> BinaryTree<T>::remove_pvt(std::unique_ptr<TreeNode<
     if (node->m_left == nullptr && node->m_right == nullptr)
     {
       // Node has no children: since `node` is a `unique_ptr`, it will be automatically deleted
-      node = nullptr;
+      node = nullptr; // Calls the destructor of the node
     }
     else if (node->m_left == nullptr)
     {
@@ -107,26 +113,33 @@ std::unique_ptr<TreeNode<T>> BinaryTree<T>::remove_pvt(std::unique_ptr<TreeNode<
     }
     else
     {
-      // Node has two children: replace it with the minimum value in the right subtree
-      TreeNode<T>* temp = findMin_pvt(node->m_right.get());
-      node->m_value = temp->m_value;
-      node->m_right = remove_pvt(std::move(node->m_right), temp->m_value);
+      // Node has two children: replace its value with the value contained in the minimum node of the right subtree
+      const std::unique_ptr<TreeNode<T>>& temp = findMin_pvt(node->m_right); // Find the minimum node in the right subtree
+      node->m_value = temp->m_value; // Replace the node's value, effectively "removing" the node
+      node->m_right = remove_pvt(std::move(node->m_right), temp->m_value); // Remove the minimum node from the right subtree
     }
   }
 
   return node;
 }
 
+/**
+ * @brief Find the minimum node in the tree.
+ * Receives a reference to a `const` unique pointer to a `TreeNode` because the node is not modified during the search.
+ *
+ * @param node the node to start the search from
+ * @return `const std::unique_ptr<TreeNode<T>>&` reference to the minimum node in the tree
+ **/
 template <typename T>
-TreeNode<T>* BinaryTree<T>::findMin_pvt(TreeNode<T>* node) const
+const std::unique_ptr<TreeNode<T>>& BinaryTree<T>::findMin_pvt(const std::unique_ptr<TreeNode<T>>& node) const
 {
-  while (node->m_left != nullptr)
+  const std::unique_ptr<TreeNode<T>>* current = &node; // Pointer to the current node. Used to traverse the tree
+  while ((*current)->m_left != nullptr)
   {
-    node = node->m_left.get();
+    current = &((*current)->m_left);
   }
 
-  return node;
+  return *current;
 }
-
 
 } // namespace ddlib

--- a/include/binarytree/tree_node.h
+++ b/include/binarytree/tree_node.h
@@ -6,6 +6,8 @@
 #ifndef TREENODE_H
 #define TREENODE_H
 
+#include <memory>
+
 namespace ddlib
 {
 
@@ -18,8 +20,8 @@ template <typename T>
 struct TreeNode
 {
   T m_value;
-  TreeNode* m_left  = nullptr;
-  TreeNode* m_right = nullptr;
+  std::unique_ptr<TreeNode> m_left  = nullptr;
+  std::unique_ptr<TreeNode> m_right = nullptr;
 
   TreeNode(const T &value)
   : m_value(value)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-message("\n*** Configuring tests for SimpleLogger library ***\n")
+message("\n*** Configuring tests for ${PROJECT_NAME} library ***\n")
 
 include(FetchContent) # Include the `FetchContent` module, used to download and unpack external projects at configure time.
 

--- a/tests/comparable.h
+++ b/tests/comparable.h
@@ -15,7 +15,7 @@ class Comparable
 public:
   Comparable(int value) : m_value(value) {}
   bool  operator<(const Comparable& other) const { return m_value <  other.m_value; }
-  bool operator==(const Comparable& other) const { return m_value == other.m_value; }
+  bool operator==(const Comparable& other) const { return m_value == other.m_value; } // Only used for testing purposes by Google Test
 
 private:
   int m_value;

--- a/tests/test_binary_tree.cpp
+++ b/tests/test_binary_tree.cpp
@@ -56,6 +56,19 @@ TEST(BinaryTreeTest, InsertNotComparable)
   // ddlib::BinaryTree<NotComparable> tree;
 }
 
+// Same as above, but with type `std::string`
+TEST(BinaryTreeTest, InsertAndSearchString)
+{
+  ddlib::BinaryTree<std::string> tree;
+  tree.insert("hello");
+  tree.insert("world");
+
+  EXPECT_TRUE(tree.search("hello"));
+  EXPECT_TRUE(tree.search("world"));
+  EXPECT_FALSE(tree.search("foo"));
+}
+
+
 // // Defining a `main` function in the test source file is optional for the Google Test framework, because it provides
 // a default one that can be linked in CMakeLists.txt. A custom `main` function can be defined to run the tests in a
 // specific order or to perform additional setup or teardown operations.


### PR DESCRIPTION
- Both `BinaryTree` and `TreeNode` classes now use smart pointers to manage internal data.
- Added code documentation.
- Added a test.

Closes #3.