### PR TITLE
Implement `SerDes` class for serialising and deserialising `BinaryTree`

### DIFF
--- a/include/binarytree/binary_tree.h
+++ b/include/binarytree/binary_tree.h
@@ -8,6 +8,7 @@
 
 #include "tree_helpers/tree_node.h"
 #include "tree_helpers/tree_iterator.h"
+#include "tree_helpers/serdes.h"
 #include <memory>
 #include <functional> // Used for traversal functions
 
@@ -94,6 +95,7 @@ public:
 
 private:
   std::unique_ptr<TreeNode<T>> m_root;
+  SerDes<T> m_serdes;
 
   // ---- Helper methods ---- //
 

--- a/include/binarytree/tree_helpers/serdes.h
+++ b/include/binarytree/tree_helpers/serdes.h
@@ -1,0 +1,25 @@
+#ifndef SERDES_H
+#define SERDES_H
+
+#include "tree_node.h"
+
+namespace ddlib
+{
+
+template <Comparable T>
+class SerDes
+{
+public:
+  void serialise(const std::string& filename, const std::unique_ptr<TreeNode<T>>& root) const;
+  std::unique_ptr<TreeNode<T>> deserialise(const std::string& filename) const;
+
+private:
+  void serialiseNode_pvt(std::ofstream& outFile, const std::unique_ptr<TreeNode<T>>& node) const;
+  std::unique_ptr<TreeNode<T>> deserialiseNode_pvt(std::istringstream& inStream) const;
+};
+
+} // namespace ddlib
+
+#include "serdes.tpp"
+
+#endif // SERDES_H

--- a/include/binarytree/tree_helpers/tree_node.h
+++ b/include/binarytree/tree_helpers/tree_node.h
@@ -15,6 +15,7 @@ namespace ddlib
 // Forward declarations. Necessary to declare the `BinaryTree` and `Iterator` classes as friends.
 template <Comparable T> class BinaryTree;
 template <Comparable T> class Iterator;
+template <Comparable T> class SerDes;
 
 /**
  * @brief A node in a binary tree.
@@ -35,6 +36,7 @@ private:
   // Allow access to private members
   friend class BinaryTree<T>;
   friend class Iterator<T>;
+  friend class SerDes<T>;
 
   /**
    * @brief The value stored in the node. Can be any type that supports the `<` and `>` operators.

--- a/src/binarytree/binary_tree.tpp
+++ b/src/binarytree/binary_tree.tpp
@@ -263,95 +263,13 @@ Iterator<T> BinaryTree<T>::getIterator() const
 template <Comparable T>
 void BinaryTree<T>::serialise(const std::string& filename) const
 {
-  std::ofstream outFile(filename);
-  if (!outFile)
-    throw std::runtime_error("Cannot open file for writing");
-
-  serialiseNode_pvt(outFile, m_root);
-  outFile.close();
+  m_serdes.serialise(filename, m_root);
 }
 
 template <Comparable T>
 void BinaryTree<T>::deserialise(const std::string& filename)
 {
-  std::ifstream inFile(filename);
-  if (!inFile)
-    throw std::runtime_error("Cannot open file for reading");
-
-  std::stringstream buffer;
-  buffer << inFile.rdbuf(); // Read the binary file into a stringstream
-  std::string dataString = buffer.str(); // Extract the string from the stringstream
-  std::istringstream dataStream(dataString); // Create an input string stream from the string
-  m_root = deserialiseNode_pvt(dataStream);
-  inFile.close();
-}
-
-template <Comparable T>
-void BinaryTree<T>::serialiseNode_pvt(std::ofstream& outFile, const std::unique_ptr<TreeNode<T>>& node) const
-{
-  if (node)
-  {
-    if constexpr (std::is_same_v<T, std::string>)
-      outFile << "\"" << node->m_value << "\" "; // Use double quotes to denote string values
-    else
-      outFile << node->m_value << " "; // Use a space to separate values
-
-    serialiseNode_pvt(outFile, node->m_left);
-    serialiseNode_pvt(outFile, node->m_right);
-  }
-  else
-  {
-    outFile << "# "; // Use '#' to denote null nodes. The space is used to separate values
-  }
-}
-
-template <Comparable T>
-std::unique_ptr<TreeNode<T>> BinaryTree<T>::deserialiseNode_pvt(std::istringstream& inStream)
-{
-  std::string valueFromStream;
-  inStream >> valueFromStream; // Read the next value from the stream up to the next space. The binary file has been converted to an istringstream by the caller
-
-  if (valueFromStream == "#")
-  {
-    return nullptr; // Base case: null node
-  }
-  else
-  {
-    T nodeValue; // The value to store in the node. Can be a `std::string` or a primitive type
-
-    if constexpr (std::is_same_v<T, std::string>)
-    {
-      // `T` is a string type
-      if (valueFromStream.front() == '"')
-      {
-        // Start of a quoted string
-        std::string restOfString;
-        if (valueFromStream.back() != '"')
-        {
-          // The string contains spaces, and must be read until the closing double quote
-          std::getline(inStream, restOfString, '"'); // Read the rest of the string until the closing double quote
-          nodeValue = valueFromStream.substr(1) + restOfString; // Combine the parts without adding an extra space
-        }
-        else
-        {
-          // The string does not contain spaces, and can be read directly
-          nodeValue = valueFromStream.substr(1, valueFromStream.size() - 2); // Remove the double quotes
-        }
-      }
-      else
-      {
-        throw std::runtime_error("Malformed string in serialised data");
-      }
-    }
-    else
-    {
-      std::istringstream(valueFromStream) >> nodeValue; // `T` is a primitive type
-    }
-    auto node = std::make_unique<TreeNode<T>>(nodeValue);
-    node->m_left  = deserialiseNode_pvt(inStream);
-    node->m_right = deserialiseNode_pvt(inStream);
-    return node;
-  }
+  m_root = m_serdes.deserialise(filename);
 }
 
 } // namespace ddlib

--- a/src/binarytree/tree_helpers/serdes.tpp
+++ b/src/binarytree/tree_helpers/serdes.tpp
@@ -1,0 +1,102 @@
+#include <fstream>
+#include <sstream>
+
+namespace ddlib
+{
+
+template <Comparable T>
+void SerDes<T>::serialise(const std::string& filename, const std::unique_ptr<TreeNode<T>>& root) const
+{
+  std::ofstream outFile(filename);
+  if (!outFile)
+    throw std::runtime_error("Cannot open file for writing");
+
+  serialiseNode_pvt(outFile, root);
+  outFile.close();
+}
+
+template <Comparable T>
+std::unique_ptr<TreeNode<T>> SerDes<T>::deserialise(const std::string& filename) const
+{
+  std::ifstream inFile(filename);
+  if (!inFile)
+    throw std::runtime_error("Cannot open file for reading");
+
+  std::stringstream buffer;
+  buffer << inFile.rdbuf();
+  std::string dataString = buffer.str();
+  std::istringstream dataStream(dataString);
+  auto root = deserialiseNode_pvt(dataStream);
+  inFile.close();
+  return root;
+}
+
+template <Comparable T>
+void SerDes<T>::serialiseNode_pvt(std::ofstream& outFile, const std::unique_ptr<TreeNode<T>>& node) const
+{
+  if (node)
+  {
+    if constexpr (std::is_same_v<T, std::string>)
+      outFile << "\"" << node->m_value << "\" "; // Use double quotes to denote string values
+    else
+      outFile << node->m_value << " "; // Use a space to separate values
+
+    serialiseNode_pvt(outFile, node->m_left);
+    serialiseNode_pvt(outFile, node->m_right);
+  }
+  else
+  {
+    outFile << "# "; // Use '#' to denote null nodes. The space is used to separate values
+  }
+}
+
+template <Comparable T>
+std::unique_ptr<TreeNode<T>> SerDes<T>::deserialiseNode_pvt(std::istringstream& inStream) const
+{
+  std::string valueFromStream;
+  inStream >> valueFromStream; // Read the next value from the stream up to the next space. The binary file has been converted to an istringstream by the caller
+
+  if (valueFromStream == "#")
+  {
+    return nullptr; // Base case: null node
+  }
+  else
+  {
+    T nodeValue; // The value to store in the node. Can be a `std::string` or a primitive type
+
+    if constexpr (std::is_same_v<T, std::string>)
+    {
+      // `T` is a string type
+      if (valueFromStream.front() == '"')
+      {
+        // Start of a quoted string
+        std::string restOfString;
+        if (valueFromStream.back() != '"')
+        {
+          // The string contains spaces, and must be read until the closing double quote
+          std::getline(inStream, restOfString, '"'); // Read the rest of the string until the closing double quote
+          nodeValue = valueFromStream.substr(1) + restOfString; // Combine the parts without adding an extra space
+        }
+        else
+        {
+          // The string does not contain spaces, and can be read directly
+          nodeValue = valueFromStream.substr(1, valueFromStream.size() - 2); // Remove the double quotes
+        }
+      }
+      else
+      {
+        throw std::runtime_error("Malformed string in serialised data");
+      }
+    }
+    else
+    {
+      std::istringstream(valueFromStream) >> nodeValue; // `T` is a primitive type
+    }
+    auto node = std::make_unique<TreeNode<T>>(nodeValue);
+    node->m_left  = deserialiseNode_pvt(inStream);
+    node->m_right = deserialiseNode_pvt(inStream);
+    return node;
+  }
+}
+
+} // namespace ddlib


### PR DESCRIPTION
- Added `serdes.h` header file to declare the `SerDes` class template.
- Implemented `SerDes` class template in `serdes.tpp` for serialising and deserialising a binary tree.
  - `serialise` method to serialise the tree to a file.
  - `deserialise` method to deserialise the tree from a file.
  - Private helper methods `serialiseNode_pvt` and `deserialiseNode_pvt` for recursive serialisation and deserialisation of tree nodes.
- The methods in `SerDes` were originally defined in the `BinaryTree` class, but have been moved out of it and into the `SerDes` class for better separation of concerns.
- Updated `binary_tree.h` to include `serdes.h` and added a `SerDes` data member to the `BinaryTree` class to manage serialisation and deserialisation.
- Changed `serialise` and `deserialise` methods in `binary_tree.tpp` to delegate to the `SerDes` class for serialisation and deserialisation.
- Ensured that the `SerDes` class is correctly associated with the `ddlib` namespace in `serdes.tpp`.
- Updated `tree_node.h` to declare `SerDes` as a friend class of `TreeNode` to allow access to private members during serialisation and deserialisation.
- Closes #18.