### PR TITLE
Rename `Iterator` to `TreeIterator`

### DIFF
--- a/include/binarytree/binary_tree.h
+++ b/include/binarytree/binary_tree.h
@@ -76,22 +76,22 @@ public:
   void levelOrderTraversal(const std::function<void(const T&)>& visit_cbck) const;
 
   /**
-   * @brief Serialises the binary tree to a file.
+   * @brief Serialises the binary tree to a file. Only supports primitive types and `std::string` for type `T`.
    * @param filename The name of the file to serialise the tree to.
    **/
   void serialise(const std::string& filename) const;
 
   /**
-   * @brief Deserialises the binary tree from a file.
+   * @brief Deserialises the binary tree from a file. Only supports primitive types and `std::string` for type `T`.
    * @param filename The name of the file to deserialise the tree from.
    **/
   void deserialise(const std::string& filename);
 
   /**
    * @brief Get an iterator for the binary tree, always starting at the root node.
-   * @return `Iterator` An iterator for the binary tree.
+   * @return `TreeIterator` An iterator for the binary tree.
    **/
-  Iterator<T> getIterator() const;
+  TreeIterator<T> getIterator() const;
 
 private:
   std::unique_ptr<TreeNode<T>> m_root;

--- a/include/binarytree/tree_helpers/serdes.h
+++ b/include/binarytree/tree_helpers/serdes.h
@@ -6,6 +6,19 @@
 namespace ddlib
 {
 
+/**
+ * @brief Serialisation and deserialisation class for the `BinaryTree` class.
+ *
+ * The `SerDes` class provides methods to serialise and deserialise a binary tree to/from a file.
+ *
+ * Don't create an instance of this class. Instead, use the `BinaryTree` class's methods to serialise and deserialise the
+ * tree.
+ *
+ * @tparam T The type of the values stored in the tree. It must support the `<` and `>` operators.
+ * @see BinaryTree
+ * @see TreeNode
+ * @see TreeIterator
+ **/
 template <Comparable T>
 class SerDes
 {

--- a/include/binarytree/tree_helpers/tree_iterator.h
+++ b/include/binarytree/tree_helpers/tree_iterator.h
@@ -1,6 +1,6 @@
 /**
  * @file tree_iterator.h
- * @brief Definition of the `Iterator` class for the `BinaryTree`.
+ * @brief Definition of the `TreeIterator` class for the `BinaryTree`.
  **/
 
 #ifndef TREE_ITERATOR_H
@@ -27,10 +27,10 @@ template <Comparable T> class BinaryTree; // Forward declaration
  * @see TreeNode
  **/
 template <Comparable T>
-class Iterator
+class TreeIterator
 {
 public:
-  Iterator(TreeNode<T>* root);
+  TreeIterator(TreeNode<T>* root);
 
   /**
    * @brief Move to the left child of the current node.

--- a/include/binarytree/tree_helpers/tree_node.h
+++ b/include/binarytree/tree_helpers/tree_node.h
@@ -12,9 +12,9 @@
 namespace ddlib
 {
 
-// Forward declarations. Necessary to declare the `BinaryTree` and `Iterator` classes as friends.
+// Forward declarations. Necessary to declare the `BinaryTree` and `TreeIterator` classes as friends.
 template <Comparable T> class BinaryTree;
-template <Comparable T> class Iterator;
+template <Comparable T> class TreeIterator;
 template <Comparable T> class SerDes;
 
 /**
@@ -35,7 +35,7 @@ private:
 
   // Allow access to private members
   friend class BinaryTree<T>;
-  friend class Iterator<T>;
+  friend class TreeIterator<T>;
   friend class SerDes<T>;
 
   /**

--- a/src/binarytree/binary_tree.tpp
+++ b/src/binarytree/binary_tree.tpp
@@ -253,9 +253,9 @@ void BinaryTree<T>::postOrderTraversal_pvt(const std::unique_ptr<TreeNode<T>>& n
 // ---- Iterator Methods ---- //
 
 template <Comparable T>
-Iterator<T> BinaryTree<T>::getIterator() const
+TreeIterator<T> BinaryTree<T>::getIterator() const
 {
-  return Iterator(m_root.get()); // Calls the constructor of the `Iterator` class
+  return TreeIterator(m_root.get()); // Calls the constructor of the `TreeIterator` class
 }
 
 // ---- Serialisation and Deserialisation Methods ---- //

--- a/src/binarytree/tree_helpers/tree_iterator.tpp
+++ b/src/binarytree/tree_helpers/tree_iterator.tpp
@@ -1,10 +1,10 @@
 template <Comparable T>
-Iterator<T>::Iterator(TreeNode<T>* root)
+TreeIterator<T>::TreeIterator(TreeNode<T>* root)
   : m_current(root)
 {}
 
 template <Comparable T>
-bool Iterator<T>::moveToLeftChild()
+bool TreeIterator<T>::moveToLeftChild()
 {
   if (m_current && m_current->m_left) // Also check the current node is not null because dereferencing a null pointer is undefined behavior
   {
@@ -15,7 +15,7 @@ bool Iterator<T>::moveToLeftChild()
 }
 
 template <Comparable T>
-bool Iterator<T>::moveToRightChild()
+bool TreeIterator<T>::moveToRightChild()
 {
   if (m_current && m_current->m_right)
   {
@@ -26,7 +26,7 @@ bool Iterator<T>::moveToRightChild()
 }
 
 template <Comparable T>
-const T& Iterator<T>::getValue() const
+const T& TreeIterator<T>::getValue() const
 {
   if (m_current)
   {
@@ -36,7 +36,7 @@ const T& Iterator<T>::getValue() const
 }
 
 template <Comparable T>
-void Iterator<T>::setValue(const T& value)
+void TreeIterator<T>::setValue(const T& value)
 {
   if (m_current)
   {
@@ -49,13 +49,13 @@ void Iterator<T>::setValue(const T& value)
 }
 
 template <Comparable T>
-bool Iterator<T>::isValid() const
+bool TreeIterator<T>::isValid() const
 {
   return m_current != nullptr;
 }
 
 template <Comparable T>
-bool Iterator<T>::isLeaf() const
+bool TreeIterator<T>::isLeaf() const
 {
   if (m_current)
   {
@@ -65,7 +65,7 @@ bool Iterator<T>::isLeaf() const
 }
 
 template <Comparable T>
-bool Iterator<T>::createChildren(const T &leftValue, const T &rightValue)
+bool TreeIterator<T>::createChildren(const T &leftValue, const T &rightValue)
 {
   if (m_current && !m_current->m_left && !m_current->m_right)
   {


### PR DESCRIPTION
- Renamed `Iterator` class to `TreeIterator` for clarity and to avoid confusion with the standard library iterators.
- Updated Doxygen documentation to reflect the changes.
- Closes #24.