### PR TITLE
Improvement: make `SerDes` methods private

### DIFF
--- a/include/binarytree/tree_helpers/serdes.h
+++ b/include/binarytree/tree_helpers/serdes.h
@@ -22,11 +22,12 @@ namespace ddlib
 template <Comparable T>
 class SerDes
 {
-public:
-  void serialise(const std::string& filename, const std::unique_ptr<TreeNode<T>>& root) const;
-  std::unique_ptr<TreeNode<T>> deserialise(const std::string& filename) const;
-
 private:
+  friend class BinaryTree<T>; // Users should use the `BinaryTree` class's methods to serialise and deserialise the tree
+
+  void serialise(const std::string& filename, const std::unique_ptr<TreeNode<T>>& root) const; // Serialise the tree to a file. Use the `BinaryTree` class's public method instead.
+  std::unique_ptr<TreeNode<T>> deserialise(const std::string& filename) const; // Deserialise the tree from a file. Use the `BinaryTree` class's public method instead.
+
   void serialiseNode_pvt(std::ofstream& outFile, const std::unique_ptr<TreeNode<T>>& node) const;
   std::unique_ptr<TreeNode<T>> deserialiseNode_pvt(std::istringstream& inStream) const;
 };

--- a/src/binarytree/binary_tree.tpp
+++ b/src/binarytree/binary_tree.tpp
@@ -263,13 +263,13 @@ TreeIterator<T> BinaryTree<T>::getIterator() const
 template <Comparable T>
 void BinaryTree<T>::serialise(const std::string& filename) const
 {
-  m_serdes.serialise(filename, m_root);
+  m_serdes.serialise(filename, m_root); // Delegate the serialisation to the `SerDes` class
 }
 
 template <Comparable T>
 void BinaryTree<T>::deserialise(const std::string& filename)
 {
-  m_root = m_serdes.deserialise(filename);
+  m_root = m_serdes.deserialise(filename); // Delegate the deserialisation to the `SerDes` class
 }
 
 } // namespace ddlib


### PR DESCRIPTION
- `SerDes`'s methods are declared as private, and `BinaryTree` is declared as a friend class, to prevent users from directly interacting with `SerDes`.
- Updated Doxygen documentation to reflect the changes.
- Closes #28.