### PR TITLE
Improvement: Simplify `#include` directives

### DIFF
--- a/include/binarytree/binary_tree.h
+++ b/include/binarytree/binary_tree.h
@@ -6,11 +6,11 @@
 #ifndef BINARYTREE_H
 #define BINARYTREE_H
 
-#include "tree_helpers/tree_node.h"
-#include "tree_helpers/tree_iterator.h"
-#include "tree_helpers/serdes.h"
-#include <memory>
 #include <functional> // Used for traversal functions
+#include "tree_helpers/serdes.h"
+
+class TreeNode;
+class TreeIterator;
 
 namespace ddlib
 {

--- a/src/binarytree/binary_tree.tpp
+++ b/src/binarytree/binary_tree.tpp
@@ -5,7 +5,9 @@
 
 #include <queue>   // Used for level-order traversal
 #include <fstream> // Used for serialisation / deserialisation
-#include <sstream> // Used for deserialisation
+#include <sstream> // Used for serialisation / deserialisation
+#include "binarytree/tree_helpers/tree_node.h"
+#include "binarytree/tree_helpers/tree_iterator.h"
 
 namespace ddlib
 {


### PR DESCRIPTION
- Removed unnecessary `#include` directives from the `binary_tree.h` header file.
- The removed includes were either moved to `binary_tree.tpp`, or replaced by a forward declaration.
- The result is a much cleaner inclusion graph.
- Closes #27.